### PR TITLE
Make download directory configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,6 +45,7 @@ type Client struct {
 // ClientConfig specifies the behaviour of a client.
 type ClientConfig struct {
 	TorrentPath    string
+	DataDir        string
 	Port           int
 	TorrentPort    int
 	Seed           bool
@@ -73,7 +74,7 @@ func NewClient(cfg ClientConfig) (client Client, err error) {
 
 	// Create client.
 	c, err = torrent.NewClient(&torrent.Config{
-		DataDir:    os.TempDir(),
+		DataDir:    cfg.DataDir,
 		NoUpload:   !cfg.Seed,
 		Seed:       cfg.Seed,
 		DisableTCP: !cfg.TCP,

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	flag.BoolVar(&cfg.Seed, "seed", cfg.Seed, "Seed after finished downloading")
 	flag.IntVar(&cfg.MaxConnections, "conn", cfg.MaxConnections, "Maximum number of connections")
 	flag.BoolVar(&cfg.TCP, "tcp", cfg.TCP, "Allow connections via TCP")
+	flag.StringVar(&cfg.DataDir, "datadir", os.TempDir(), "Where to download torrent data")
 	flag.Parse()
 	if len(flag.Args()) == 0 {
 		flag.Usage()


### PR DESCRIPTION
My reasoning: I have Arch Linux it has /tmp dir mounted as tmpfs in RAM. I have only 4G of RAM installed so I can only d/l torrents below 2G limit with go-peerlix (half of my RAM size)